### PR TITLE
Updated ramsey/uuid werkspot/enum and php

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,7 +8,7 @@ checks:
 build:
     environment:
         php:
-            version: 7.2
+            version: 7.3
     tests:
         override:
             -

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
         }
     },
     "require": {
-        "php": ">=7.1",
-        "werkspot/enum": "^2.1",
+        "php": ">=7.3",
+        "werkspot/enum": "^3.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-zip": "*",
-        "ramsey/uuid": "^3.9"
+        "ramsey/uuid": "^3 || ^4"
     },
     "suggest": {
         "ext-exif": "*",


### PR DESCRIPTION
Ramsey/uuid: 3.9 -> 4.0
Werkspot/enum: 2.1 -> 3.0
Php: >= 7.1 -> >= 7.3 

We should release a new major release I think because of the php 7.3 vs 7.1 requirement